### PR TITLE
Automatically deploy the habitat web site if it changed

### DIFF
--- a/habitat/default.toml
+++ b/habitat/default.toml
@@ -12,6 +12,14 @@ ssh_user = "change_me_to_you"
 ssh_private_key = "/hab/sentinels/files/ssh-rsa"
 # SSH Public Key for that user, as a filesystem path
 ssh_public_key = "/hab/sentinels/files/ssh-rsa.pub"
+# AWS_ACCESS_KEY_ID for deploying the web site
+aws_access_key_id = "this"
+# AWS_SECRET_ACCESS_KEY for deploying the web site
+aws_secret_access_key = "is"
+# FASTLY_API_KEY for invalidating the fastly cache of the web site
+fastly_api_key = "all"
+# FASTLY_SERVICE_KEY for doing the fastly stuff for the web site
+fastly_service_key = "fake"
 
 ###
 # Define repositories by name, with a list of github id's who
@@ -23,6 +31,3 @@ ssh_public_key = "/hab/sentinels/files/ssh-rsa.pub"
 #   "jdunn",
 #   "adamhjk",
 # ]
-
-
-


### PR DESCRIPTION
I didn't actually deploy the web site with this, but I did enough testing to verify that when a file inside of `www` changes, the `deploy!` method gets called, and when nothing in `www` changes, nothing happens.

![gif-keyboard-9624020329895427058](https://cloud.githubusercontent.com/assets/947/20024040/0b330824-a2a1-11e6-8e31-0c0752119974.gif)


Signed-off-by: Josh Black <raskchanky@gmail.com>