### PR TITLE
Revert "Automatically deploy the habitat web site if it changed"

### DIFF
--- a/habitat/default.toml
+++ b/habitat/default.toml
@@ -12,14 +12,6 @@ ssh_user = "change_me_to_you"
 ssh_private_key = "/hab/sentinels/files/ssh-rsa"
 # SSH Public Key for that user, as a filesystem path
 ssh_public_key = "/hab/sentinels/files/ssh-rsa.pub"
-# AWS_ACCESS_KEY_ID for deploying the web site
-aws_access_key_id = "this"
-# AWS_SECRET_ACCESS_KEY for deploying the web site
-aws_secret_access_key = "is"
-# FASTLY_API_KEY for invalidating the fastly cache of the web site
-fastly_api_key = "all"
-# FASTLY_SERVICE_KEY for doing the fastly stuff for the web site
-fastly_service_key = "fake"
 
 ###
 # Define repositories by name, with a list of github id's who
@@ -31,3 +23,6 @@ fastly_service_key = "fake"
 #   "jdunn",
 #   "adamhjk",
 # ]
+
+
+

--- a/lib/sentinel.rb
+++ b/lib/sentinel.rb
@@ -19,56 +19,6 @@ module Sentinel
     end
   end
 
-  class WWW
-    def initialize(pr, branch)
-      @pr = pr
-      @branch = branch
-    end
-
-    def path
-      name = @pr["base"]["repo"]["name"]
-      path = File.join(CACHE, name)
-    end
-
-    def www_path
-      File.join(path, "www")
-    end
-
-    def modified?
-      mb = Mixlib::ShellOut.new("git merge-base #{@branch} master", :cwd => path)
-      mb.run_command
-      mb.error!
-
-      cmd = Mixlib::ShellOut.new("git diff --name-only #{@branch} #{mb.stdout.chomp}", :cwd => path)
-      cmd.run_command
-      cmd.error!
-
-      cmd.stdout.split("\n").any? { |f| f =~ /www\// }
-    end
-
-    def configured?
-      CONFIG["cfg"]["aws_access_key_id"] &&
-        CONFIG["cfg"]["aws_secret_access_key"] &&
-        CONFIG["cfg"]["fastly_api_key"] &&
-        CONFIG["cfg"]["fastly_service_key"]
-    end
-
-    def env
-      {
-        "AWS_ACCESS_KEY_ID" => CONFIG["cfg"]["aws_access_key_id"],
-        "AWS_SECRET_ACCESS_KEY" => CONFIG["cfg"]["aws_secret_access_key"],
-        "FASTLY_API_KEY" => CONFIG["cfg"]["fastly_api_key"],
-        "FASTLY_SERVICE_KEY" => CONFIG["cfg"]["fastly_service_key"]
-      }
-    end
-
-    def deploy!
-      cmd = Mixlib::ShellOut.new("make deploy", :env => env, :cwd => www_path)
-      cmd.run_command
-      cmd.error!
-    end
-  end
-
   class Git
     class << self
       def env
@@ -131,6 +81,7 @@ module Sentinel
         cmd.run_command
         cmd.error!
       end
+
     end
   end
 
@@ -215,7 +166,7 @@ module Sentinel
         merge(pr)
       end
 
-      def merge_real_pr(pr, testing_branch)
+      def merge_real_pr(pr)
         begin
           owner = pr["base"]["repo"]["owner"]["login"]
           repo = pr["base"]["repo"]["name"]
@@ -231,6 +182,7 @@ module Sentinel
             pr["number"],
             commit_message: "Approved by: @#{approver}\nMerged by: The Sentinels"
           )
+
         rescue => e
           Sentinel.github.issues.comments.create(
             pr["repository"]["owner"]["login"],
@@ -239,26 +191,6 @@ module Sentinel
             body: "Sorry. I had a problem merging this pull request. The error was:\n\n```ruby\n#{e}\n```\n\n![Oops](https://cloud.githubusercontent.com/assets/4304/17756537/583f4ba4-6495-11e6-97c8-0c22ceaf7e63.gif)"
           )
         end
-
-        begin
-          puts "Checking to see if the web site needs to be deployed"
-          www = Sentinel::WWW.new(pr, testing_branch)
-
-          if www.modified?
-            puts "The web site was modified. I'm going to try to deploy it now."
-
-            if www.configured?
-              www.deploy!
-            else
-              puts "I'd like to deploy the web site for you right now but I'm missing the 4 ENV vars necessary to do so."
-            end
-          else
-            puts "The web site was not modified. Moving on."
-          end
-        rescue => e
-          puts "Failed to deploy the web site because #{e.inspect}"
-        end
-
         begin
           puts "Deleting integration branch"
           Sentinel.github.git.references.delete(
@@ -337,7 +269,7 @@ module Sentinel
 
       if build['type'] == "pull_request"
         puts "Nothing to do on a PR travis job"
-        return "Nothing to do on PR"
+        return "Nothing to do on PR" 
       end
 
       build["branch"] =~ /^sentinel\/#{build["repository"]["owner_name"]}\/#{build["repository"]["name"]}\/(\d+)/
@@ -356,7 +288,7 @@ module Sentinel
            build["repository"]["name"],
            pr
          )
-         Hub.merge_real_pr(real_pr, build["branch"])
+         Hub.merge_real_pr(real_pr)
         elsif build["result"] == 1
           Sentinel.github.issues.comments.create(
             build["repository"]["owner_name"],
@@ -463,3 +395,4 @@ CACHE = "/hab/svc/sentinel/data"
 Dir.mkdir(CACHE, 0700) unless Dir.exists?(CACHE)
 
 Sentinel::Processor.supervise(:as => :processor)
+


### PR DESCRIPTION
This reverts commit 394105076c478b2f1ee88af7ffea23eb09b2ddfd.

Before, we didn't know how to do this from travis, so I put it here.  Now we know how to do this from travis, so let's get rid of it here, and do it there instead.

![gif-keyboard-14465508843035499111](https://cloud.githubusercontent.com/assets/947/20535181/bc079f66-b098-11e6-918d-9023aa939633.gif)
