### PR TITLE
 add more allowed commit types to DCO OKs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: ruby
 rvm:
-  - 2.0.0
+  - 2.4.2


### PR DESCRIPTION
Logic lifted from the [Chef DCO Bot](https://github.com/chef/dcob/blob/a10a7f4b7c967f0bbf2268759375399b4f3d4323/src/lib/dcob/octoclient.rb#L45-L68) fork of Sentinel.

Also, update Ruby version used by Travis to bring Travis config up to date with the version of Ruby the habitat package builds against.